### PR TITLE
fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,11 +189,7 @@ class Link extends Events {
   }
 
   stop () {
-    _.each(['monitor'], k => {
-      const vp = `_${k}`
-      clearInterval(this[vp])
-      delete this[vp]
-    })
+    clearInterval(this._monitorItv)
 
     _.each(this.cache, c => {
       c.clear()

--- a/index.js
+++ b/index.js
@@ -32,7 +32,8 @@ class Link extends Events {
   post (url, data, opts, cb) {
     request.post(_.extend({
       url: url,
-      json: data
+      json: true,
+      body: data
     }, opts), cb)
   }
 


### PR DESCRIPTION

request: fix arguments  …
 - body values are passed as body
 - json is a boolean for JSON parsing

stop: clear monitor interval  …
interval name wasn't constructed properly, so process was not shutting down