### PR TITLE
add `link.startAnnouncing(key, port, opts)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ successful disconnection.
 
 Used to announce a service, e.g. a [RPC Server](#class-peerrpcserver).
 
+#### link.startAnnouncing(name, port, [otions])
+
+Keep announcing a service every ~2min (default) or specify interval in `opts.interval`
+
+#### link.stopAnnouncing(name, port)
+
+Stop announcing a service
+
 #### link.put(data, callback)
 
   - `data`

--- a/test/announce.js
+++ b/test/announce.js
@@ -1,0 +1,46 @@
+/* eslint-env mocha */
+
+'use strict'
+
+const assert = require('assert')
+const Link = require('../')
+
+const { bootTwoGrapes, killGrapes } = require('./helper')
+
+let grapes
+describe('announce and lookups', () => {
+  before(function (done) {
+    this.timeout(20000)
+
+    bootTwoGrapes((err, g) => {
+      if (err) throw err
+
+      grapes = g
+      done()
+    })
+  })
+
+  after(function (done) {
+    this.timeout(5000)
+    killGrapes(grapes, done)
+  })
+
+  it('start and stop announcing', (done) => {
+    const link = new Link({
+      grape: 'http://127.0.0.1:30001'
+    })
+    link.start()
+
+    link.startAnnouncing('test', 10000, null, (err) => {
+      if (err) throw err
+
+      link.lookup('test', {}, (err, peers) => {
+        if (err) throw err
+
+        assert.deepEqual(peers, ['127.0.0.1:10000'])
+        link.stop()
+        done()
+      })
+    })
+  })
+})


### PR DESCRIPTION
Needs tests+docs, adding that later, but basic functionality is there.

``` js
var stop = link.startAnnouncing('foo', 10000)
// will announce every 1m + ran() * 2min per default, configurable in options
// when you want to stop do, stop()
```