### PR TITLE
Replacing typo "otions" by "opts"

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ successful disconnection.
 
 Used to announce a service, e.g. a [RPC Server](#class-peerrpcserver).
 
-#### link.startAnnouncing(name, port, [otions])
+#### link.startAnnouncing(name, port, [opts])
 
 Keep announcing a service every ~2min (default) or specify interval in `opts.interval`
 


### PR DESCRIPTION
Replacing by "opts" as per documentation "[...] or specify interval in __opts__.interval"