### PR TITLE
put/get: full bep-44 spec compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,20 @@ Provides sugar for storing mutable, signed data in the DHT.
 <br/>
 [Example with putMutable](https://github.com/bitfinexcom/grenache-nodejs-link/blob/master/examples/put_get_mutable.js)
 
-#### link.get(hash, callback)
+#### link.get(hash | object, callback)
 
   - `hash` &lt;String&gt; Hash used for lookup
+  - `object` &lt;Object&gt;
+    - `hash`: &lt;String&gt; Hash used for lookup
+    - `salt`: &lt;String&gt; (optional) salt that was used if data was stored with salt. Required in those cases.
+
   - `callback` &lt;function&gt;
 
 Retrieves a stored value from the DHT via a `hash` &lt;String&gt;.
+It also supports an object, which is used to pass a previously used salt in order to retrieve the data teh salt was used upon.
+
 Callback returns `err` &lt;Object&gt; and data &lt;Object&gt;.
+
 [Example](https://github.com/bitfinexcom/grenache-nodejs-link/blob/master/examples/put_get.js).
 
 

--- a/test/put-get.js
+++ b/test/put-get.js
@@ -89,7 +89,7 @@ describe('put-get integration', () => {
     link.putMutable(data, opts, (err, hash) => {
       if (err) throw err
 
-      link.get(hash, (err, res) => {
+      link.get({ hash: hash, salt: 'foobar' }, (err, res) => {
         if (err) throw err
 
         assert.equal(res.v, 'hello world')


### PR DESCRIPTION
introduced in bittorrent-dht@8.4, a get for salted data now
requires teh salt on a get/receive.

depends on https://github.com/bitfinexcom/grenache-grape/pull/63